### PR TITLE
Add mypy config and update requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-*.idea/
+.idea/
 __pycache__/
+.mypy_cache/
 .ipynb_checkpoints/
 *.ipynb

--- a/model/gaggle_of_passengers.py
+++ b/model/gaggle_of_passengers.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from model.passenger import Passenger
 
 
@@ -14,7 +16,7 @@ class GaggleOfPassengers:
     def get_passengers_waiting(self) -> [Passenger]:
         return [passenger for passenger in self._passengers if passenger.is_waiting_for_pickup()]
 
-    def get_passengers_waiting_by_floor(self) -> {int, Passenger}:
+    def get_passengers_waiting_by_floor(self) -> Dict[int, Passenger]:
         waiting_by_floor = {}
         for passenger in self.get_passengers_waiting():
             floor = passenger._floor_entered

--- a/model/passenger.py
+++ b/model/passenger.py
@@ -1,10 +1,11 @@
 class Passenger:
     id_num = 0
-    def __init__(self, floor_entered: int, desired_floor: int):
+
+    def __init__(self, floor_entered: int, desired_floor: int) -> None:
         self._floor_entered: int = floor_entered
         self._desired_floor: int = desired_floor
 
-# todo THIJS make passenger state enum
+        # todo THIJS make passenger state enum
         self._in_elevator: bool = False
         self._dropped_off: bool = False
         self._id: int = Passenger.id_num

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+python_version = 3.6
+warn_return_any = True
+warn_unused_configs = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 name: bellhop
 channels:
+- conda-forge
 - defaults
 dependencies:
 - certifi=2016.2.28=py36_0
@@ -14,5 +15,8 @@ dependencies:
 - xz=5.2.3=0
 - zlib=1.2.11=0
 - pip:
+  - mypy==0.630
+  - mypy-extensions==0.4.1
   - pygame==1.9.4
+  - typed-ast==1.1.0
 prefix: /home/screwed99/user_installed_programs/anaconda2/envs/bellhop


### PR DESCRIPTION
Running mypy is this command: `mypy --config-file mypy.ini .`

Currently the repo is super-broken, lots of the type-checking uses incorrect syntax or is wrong, but definitely helpful to have this here now rather than later. Once this stuff is everywhere and correct, we can add `mypy` to the circleci run.

I also noticed in updated the conda stuff that none of us updated `requirements.txt` for the abstract-base-class stuff. I can think of having a couple scripts, one to be run pre-commit and one post-pull, that would help keep all of our local conda environments in-sync, but that doesn't really seem great since it's still manual. Any better ideas appreciated!
